### PR TITLE
feat: add agent mode with Claude-powered tool chaining (Phase 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.80.0",
         "@supabase/supabase-js": "^2.49.4",
         "chalk": "^5.4.1",
         "cli-table3": "^0.6.5",
@@ -31,6 +32,35 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
+      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -3143,6 +3173,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -4132,6 +4175,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dist"
   ],
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
     "@supabase/supabase-js": "^2.49.4",
     "chalk": "^5.4.1",
     "cli-table3": "^0.6.5",

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,0 +1,234 @@
+import * as readline from "node:readline";
+import chalk from "chalk";
+import ora from "ora";
+import Anthropic from "@anthropic-ai/sdk";
+import { fetchProjects, type Project } from "../lib/api.js";
+import { config, loadCredentials } from "../lib/config.js";
+import { AGENT_TOOLS, executeTool } from "../lib/agent/tools.js";
+import { buildSystemPrompt } from "../lib/agent/prompts.js";
+import {
+  createSession,
+  addUserMessage,
+  addAssistantMessage,
+  addToolResults,
+  setProject,
+  getMessages,
+  type AgentSession,
+} from "../lib/agent/context.js";
+import { formatError, logo } from "../lib/formatter.js";
+import { appendToHistory, initProjectMemory } from "../lib/memory.js";
+
+const lemon = chalk.hex("#F5E642");
+const lime = chalk.hex("#7CE850");
+
+const MAX_TOOL_ITERATIONS = 10;
+
+export async function runAgentTurn(
+  client: Anthropic,
+  session: AgentSession,
+  userInput: string,
+  onText: (delta: string) => void
+): Promise<void> {
+  addUserMessage(session, userInput);
+
+  for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+    const stream = client.messages.stream({
+      model: "claude-opus-4-6",
+      max_tokens: 4096,
+      system: buildSystemPrompt(session.currentProjectName),
+      tools: AGENT_TOOLS,
+      messages: getMessages(session),
+    });
+
+    stream.on("text", onText);
+
+    const message = await stream.finalMessage();
+    addAssistantMessage(session, message.content);
+
+    if (message.stop_reason === "end_turn") break;
+    if (message.stop_reason !== "tool_use") break;
+
+    const toolUseBlocks = message.content.filter(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use"
+    );
+    if (toolUseBlocks.length === 0) break;
+
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+
+    for (const toolBlock of toolUseBlocks) {
+      const label = toolBlock.name.replace(/_/g, " ");
+      const spinner = ora({
+        text: chalk.gray(`  Fetching ${label}...`),
+        stream: process.stderr,
+      }).start();
+
+      const result = await executeTool(
+        toolBlock.name,
+        toolBlock.input as Record<string, unknown>
+      );
+      spinner.stop();
+
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: toolBlock.id,
+        content: result,
+      });
+    }
+
+    addToolResults(session, toolResults);
+  }
+}
+
+function resolveProject(
+  projects: Project[],
+  nameOrDomain: string
+): Project | undefined {
+  const lower = nameOrDomain.toLowerCase();
+  return (
+    projects.find((p) => p.name.toLowerCase() === lower) ??
+    projects.find(
+      (p) =>
+        p.name.toLowerCase().includes(lower) ||
+        p.domain?.toLowerCase().includes(lower)
+    )
+  );
+}
+
+export async function agentCommand(projectArg?: string): Promise<void> {
+  const creds = loadCredentials();
+  if (!creds?.access_token) {
+    console.log(
+      formatError("Not logged in. Run `ezeo login` or `ezeo setup` first.")
+    );
+    process.exit(1);
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.log(
+      formatError(
+        "ANTHROPIC_API_KEY not set.\n\n  Add it to ~/.ezeo/.env:\n    ANTHROPIC_API_KEY=sk-ant-..."
+      )
+    );
+    process.exit(1);
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  const spinner = ora({ text: "Connecting...", stream: process.stderr }).start();
+  let projects: Project[] = [];
+  let currentProject: Project | undefined;
+
+  try {
+    projects = await fetchProjects();
+    const defaultId = config.get("defaultProject");
+    currentProject = projects.find((p) => p.id === defaultId) ?? projects[0];
+    if (projectArg) {
+      currentProject = resolveProject(projects, projectArg) ?? currentProject;
+    }
+    spinner.stop();
+  } catch (err) {
+    spinner.fail("Failed to connect");
+    console.log(formatError(err instanceof Error ? err.message : String(err)));
+    process.exit(1);
+  }
+
+  const session = createSession();
+
+  if (currentProject) {
+    setProject(session, currentProject.id, currentProject.name);
+    initProjectMemory(currentProject.name, currentProject.domain ?? "");
+  }
+
+  console.log();
+  console.log(logo());
+  console.log();
+  console.log(
+    `  ${lime.bold("Agent Mode")}  ${chalk.gray("—")}  ${chalk.white("Claude Opus")}`
+  );
+  if (currentProject) {
+    console.log(
+      chalk.gray(
+        `  Project: ${chalk.white(currentProject.name)} ${chalk.gray(
+          `(${currentProject.domain})`
+        )}`
+      )
+    );
+  }
+  console.log();
+  console.log(
+    chalk.gray(
+      "  Ask anything about your SEO data. I'll fetch and chain the data I need."
+    )
+  );
+  console.log(
+    chalk.gray(
+      `  Try: "What's driving my traffic drop?" or "How's my AI visibility?"`
+    )
+  );
+  console.log(chalk.gray("  Type 'exit' or 'quit' to leave."));
+  console.log();
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: lemon("agent > "),
+  });
+
+  rl.prompt();
+
+  rl.on("line", async (line) => {
+    const input = line.trim();
+    if (!input) {
+      rl.prompt();
+      return;
+    }
+
+    if (input === "exit" || input === "quit") {
+      console.log(
+        chalk.gray("\n  Goodbye! Run `ezeo agent` to start a new session.\n")
+      );
+      rl.close();
+      return;
+    }
+
+    console.log();
+    let hasOutput = false;
+
+    try {
+      await runAgentTurn(client, session, input, (delta) => {
+        process.stdout.write(chalk.white(delta));
+        hasOutput = true;
+      });
+
+      if (hasOutput) console.log("\n");
+
+      if (currentProject) {
+        appendToHistory(currentProject.name, `- Agent: \`${input}\``);
+      }
+    } catch (err) {
+      if (err instanceof Anthropic.AuthenticationError) {
+        console.log(
+          formatError(
+            "Invalid Anthropic API key. Check ANTHROPIC_API_KEY in ~/.ezeo/.env"
+          )
+        );
+      } else if (err instanceof Anthropic.RateLimitError) {
+        console.log(
+          formatError("Rate limited. Please wait a moment before trying again.")
+        );
+      } else {
+        console.log(
+          formatError(err instanceof Error ? err.message : String(err))
+        );
+      }
+      console.log();
+    }
+
+    rl.prompt();
+  });
+
+  rl.on("close", () => {
+    process.exit(0);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { logoutCommand } from "./commands/logout.js";
 import { projectsCommand, useProjectCommand } from "./commands/projects.js";
 import { statusCommand } from "./commands/status.js";
 import { chatCommand } from "./commands/chat.js";
+import { agentCommand } from "./commands/agent.js";
 import { whoamiCommand } from "./commands/whoami.js";
 import { memoryCommand } from "./commands/memory.js";
 import { croCommand } from "./commands/cro.js";
@@ -343,6 +344,22 @@ Examples:
   ezeo image "hero banner for aquaprovac.com"`
   )
   .action((description?: string) => imageCommand(description));
+
+// ---- agent ----
+program
+  .command("agent [project]")
+  .description("AI agent mode — natural language queries with automatic data chaining")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  ezeo agent                    # Start agent with default project
+  ezeo agent aqua               # Start agent focused on Aqua project
+  ezeo agent                    # Then ask: "What's driving my traffic drop?"
+
+Requires ANTHROPIC_API_KEY in ~/.ezeo/.env`
+  )
+  .action((project?: string) => agentCommand(project));
 
 // ---- chat ----
 program

--- a/src/lib/agent/context.ts
+++ b/src/lib/agent/context.ts
@@ -1,0 +1,52 @@
+import type Anthropic from "@anthropic-ai/sdk";
+
+export interface AgentSession {
+  messages: Anthropic.MessageParam[];
+  currentProjectId: string | null;
+  currentProjectName: string | null;
+  sessionStart: Date;
+}
+
+export function createSession(): AgentSession {
+  return {
+    messages: [],
+    currentProjectId: null,
+    currentProjectName: null,
+    sessionStart: new Date(),
+  };
+}
+
+export function addUserMessage(session: AgentSession, content: string): void {
+  session.messages.push({ role: "user", content });
+}
+
+export function addAssistantMessage(
+  session: AgentSession,
+  content: Anthropic.ContentBlock[]
+): void {
+  session.messages.push({ role: "assistant", content });
+}
+
+export function addToolResults(
+  session: AgentSession,
+  results: Anthropic.ToolResultBlockParam[]
+): void {
+  session.messages.push({ role: "user", content: results });
+}
+
+export function setProject(
+  session: AgentSession,
+  id: string,
+  name: string
+): void {
+  session.currentProjectId = id;
+  session.currentProjectName = name;
+}
+
+export function getMessages(session: AgentSession): Anthropic.MessageParam[] {
+  return session.messages;
+}
+
+export function getMessageCount(session: AgentSession): number {
+  return session.messages.length;
+}

--- a/src/lib/agent/prompts.ts
+++ b/src/lib/agent/prompts.ts
@@ -1,0 +1,42 @@
+export function buildSystemPrompt(projectName: string | null): string {
+  const projectContext = projectName
+    ? `The user's current active project is "${projectName}".`
+    : "The user has not set an active project yet. Use list_projects to help them choose one.";
+
+  return `You are Ezeo, an expert SEO and GEO (Generative Engine Optimization) AI assistant with direct access to the user's live SEO data via tools.
+
+${projectContext}
+
+## Your Role
+You help users understand their SEO performance, identify opportunities, and make data-driven decisions. You have real-time access to Google Search Console, Google Analytics 4, AI visibility tracking, and keyword ranking data.
+
+## Available Tools
+- **list_projects**: List all projects the user has access to
+- **get_status**: Full dashboard — GSC traffic, GA4 analytics, GEO citations, rankings overview, and top alerts
+- **get_keywords**: Top ranking keywords with positions and week-over-week changes
+- **get_insights**: Alerts and automated insights (ranking drops, traffic changes, opportunities)
+- **get_geo**: AI/GEO visibility — citation rate across ChatGPT, Perplexity, Gemini, and other AI platforms
+- **get_traffic**: Detailed traffic metrics from Search Console and Google Analytics
+
+## Tool Chaining
+Chain multiple tool calls when needed to give a complete answer:
+- For comprehensive analysis: get_status first, then get_keywords for deeper keyword data
+- For GEO recommendations: get_geo then get_insights together
+- For traffic diagnosis: get_traffic then get_keywords to correlate drops with ranking changes
+- To compare or switch projects: list_projects then get_status for the relevant project
+
+## Response Style
+- Be concise and data-driven — lead with the most important findings
+- Include specific numbers and percentages from the data
+- Highlight wins (positive trends) and concerns (drops, issues) clearly
+- Give 1-3 actionable next steps based on the actual data
+- Plain text only — this is a terminal UI, no markdown headers or bullet asterisks
+- Remember context from earlier in the conversation (project, past queries)
+
+## SEO/GEO Domain Knowledge
+- CTR below 2%: title tag and meta description optimization needed
+- Positions 4-10: near-miss opportunities — content refresh and internal linking can push to top 3
+- AI citation rate below 30%: FAQ schema markup, YouTube content, and PR/brand mentions help most
+- Traffic drop >10% WoW: investigate ranking losses immediately with get_keywords
+- Keywords with large position drops (>5): prioritize content refresh on those pages`;
+}

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -1,0 +1,179 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import {
+  fetchProjects,
+  fetchGSCMetricsWoW,
+  fetchGA4MetricsWoW,
+  fetchGEOMetrics,
+  fetchRankingsSummary,
+  fetchInsights,
+  fetchTopKeywords,
+  fetchGSCMetrics,
+  fetchGA4Metrics,
+} from "../api.js";
+
+export const AGENT_TOOLS: Anthropic.Tool[] = [
+  {
+    name: "list_projects",
+    description: "List all SEO projects the user has access to, with their connection status for GSC, GA4, and Shopify.",
+    input_schema: {
+      type: "object" as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: "get_status",
+    description:
+      "Get the full SEO dashboard for a project: GSC traffic (clicks, impressions, CTR, position), GA4 analytics (sessions, pageviews, bounce rate), GEO/AI citation metrics, rankings summary, and top insights/alerts.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The project ID to get status for",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
+    name: "get_keywords",
+    description:
+      "Get top ranking keywords with their current positions and week-over-week position changes. Negative change means improvement (moved up). Positive change means drop (moved down).",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The project ID to get keywords for",
+        },
+        limit: {
+          type: "number",
+          description: "Number of keywords to fetch (default: 20, max: 50)",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
+    name: "get_insights",
+    description:
+      "Get automated SEO alerts and insights for a project: ranking drops, traffic anomalies, CTR issues, and improvement opportunities. Each insight has a severity (critical, warning, info).",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The project ID to get insights for",
+        },
+        limit: {
+          type: "number",
+          description: "Number of insights to fetch (default: 10)",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
+    name: "get_geo",
+    description:
+      "Get AI/GEO visibility metrics: total citations, citation rate percentage, and breakdown by AI platform (ChatGPT, Perplexity, Gemini, Claude, Bing Copilot, etc.).",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The project ID to get GEO metrics for",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
+    name: "get_traffic",
+    description:
+      "Get detailed traffic metrics from Google Search Console (clicks, impressions, CTR, average position) and Google Analytics 4 (sessions, pageviews, bounce rate, average session duration).",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The project ID to get traffic metrics for",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+];
+
+export async function executeTool(
+  name: string,
+  input: Record<string, unknown>
+): Promise<string> {
+  try {
+    switch (name) {
+      case "list_projects": {
+        const projects = await fetchProjects();
+        if (projects.length === 0) return "No projects found.";
+        return JSON.stringify(
+          projects.map((p) => ({
+            id: p.id,
+            name: p.name,
+            domain: p.domain,
+            gsc_connected: p.search_console_connected,
+            ga4_connected: p.google_analytics_connected,
+            shopify_connected: p.shopify_connected,
+          }))
+        );
+      }
+
+      case "get_status": {
+        const projectId = input.project_id as string;
+        const [gscWoW, ga4WoW, geo, rankings, insights, topKeywords] =
+          await Promise.all([
+            fetchGSCMetricsWoW(projectId).catch(() => null),
+            fetchGA4MetricsWoW(projectId).catch(() => null),
+            fetchGEOMetrics(projectId).catch(() => null),
+            fetchRankingsSummary(projectId).catch(() => null),
+            fetchInsights(projectId, 5).catch(() => []),
+            fetchTopKeywords(projectId, 10).catch(() => []),
+          ]);
+        return JSON.stringify({ gscWoW, ga4WoW, geo, rankings, insights, topKeywords });
+      }
+
+      case "get_keywords": {
+        const projectId = input.project_id as string;
+        const limit = Math.min((input.limit as number | undefined) ?? 20, 50);
+        const keywords = await fetchTopKeywords(projectId, limit);
+        return JSON.stringify(keywords);
+      }
+
+      case "get_insights": {
+        const projectId = input.project_id as string;
+        const limit = (input.limit as number | undefined) ?? 10;
+        const insights = await fetchInsights(projectId, limit);
+        return JSON.stringify(insights);
+      }
+
+      case "get_geo": {
+        const projectId = input.project_id as string;
+        const geo = await fetchGEOMetrics(projectId);
+        return JSON.stringify(geo);
+      }
+
+      case "get_traffic": {
+        const projectId = input.project_id as string;
+        const [gsc, ga4] = await Promise.all([
+          fetchGSCMetrics(projectId).catch(() => null),
+          fetchGA4Metrics(projectId).catch(() => null),
+        ]);
+        return JSON.stringify({ gsc, ga4 });
+      }
+
+      default:
+        return `Unknown tool: ${name}`;
+    }
+  } catch (err) {
+    return `Error executing ${name}: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -1,0 +1,539 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createSession,
+  addUserMessage,
+  addAssistantMessage,
+  addToolResults,
+  setProject,
+  getMessages,
+  getMessageCount,
+} from "../src/lib/agent/context.js";
+import { buildSystemPrompt } from "../src/lib/agent/prompts.js";
+import { executeTool, AGENT_TOOLS } from "../src/lib/agent/tools.js";
+
+// ---- Mock the API module ----
+vi.mock("../src/lib/api.js", () => ({
+  fetchProjects: vi.fn(),
+  fetchGSCMetrics: vi.fn(),
+  fetchGA4Metrics: vi.fn(),
+  fetchGSCMetricsWoW: vi.fn(),
+  fetchGA4MetricsWoW: vi.fn(),
+  fetchGEOMetrics: vi.fn(),
+  fetchRankingsSummary: vi.fn(),
+  fetchInsights: vi.fn(),
+  fetchTopKeywords: vi.fn(),
+}));
+
+import * as api from "../src/lib/api.js";
+
+// ---- Context tests ----
+
+describe("createSession", () => {
+  it("creates a session with empty messages", () => {
+    const session = createSession();
+    expect(session.messages).toHaveLength(0);
+  });
+
+  it("sets null project fields by default", () => {
+    const session = createSession();
+    expect(session.currentProjectId).toBeNull();
+    expect(session.currentProjectName).toBeNull();
+  });
+
+  it("records the session start time", () => {
+    const before = new Date();
+    const session = createSession();
+    const after = new Date();
+    expect(session.sessionStart.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(session.sessionStart.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+});
+
+describe("addUserMessage", () => {
+  it("appends a user message to the session", () => {
+    const session = createSession();
+    addUserMessage(session, "How is my traffic?");
+    expect(session.messages).toHaveLength(1);
+    expect(session.messages[0].role).toBe("user");
+    expect(session.messages[0].content).toBe("How is my traffic?");
+  });
+
+  it("accumulates multiple messages", () => {
+    const session = createSession();
+    addUserMessage(session, "First question");
+    addUserMessage(session, "Second question");
+    expect(session.messages).toHaveLength(2);
+  });
+});
+
+describe("addAssistantMessage", () => {
+  it("appends an assistant message with content blocks", () => {
+    const session = createSession();
+    const contentBlocks = [{ type: "text" as const, text: "Here is your data." }];
+    addAssistantMessage(session, contentBlocks);
+    expect(session.messages).toHaveLength(1);
+    expect(session.messages[0].role).toBe("assistant");
+  });
+
+  it("preserves the full content array", () => {
+    const session = createSession();
+    const blocks = [
+      { type: "text" as const, text: "Analysis complete." },
+      { type: "text" as const, text: "Additional detail." },
+    ];
+    addAssistantMessage(session, blocks);
+    const msg = session.messages[0];
+    expect(Array.isArray(msg.content)).toBe(true);
+    if (Array.isArray(msg.content)) {
+      expect(msg.content).toHaveLength(2);
+    }
+  });
+});
+
+describe("addToolResults", () => {
+  it("appends a user message with tool results", () => {
+    const session = createSession();
+    const results = [
+      {
+        type: "tool_result" as const,
+        tool_use_id: "tool_123",
+        content: '{"clicks": 500}',
+      },
+    ];
+    addToolResults(session, results);
+    expect(session.messages).toHaveLength(1);
+    expect(session.messages[0].role).toBe("user");
+  });
+
+  it("includes the tool_use_id in the result", () => {
+    const session = createSession();
+    const results = [
+      {
+        type: "tool_result" as const,
+        tool_use_id: "tool_abc",
+        content: "result data",
+      },
+    ];
+    addToolResults(session, results);
+    const msg = session.messages[0];
+    if (Array.isArray(msg.content)) {
+      const block = msg.content[0] as { type: string; tool_use_id: string };
+      expect(block.tool_use_id).toBe("tool_abc");
+    }
+  });
+});
+
+describe("setProject", () => {
+  it("sets the current project id and name", () => {
+    const session = createSession();
+    setProject(session, "proj_123", "Acme Corp");
+    expect(session.currentProjectId).toBe("proj_123");
+    expect(session.currentProjectName).toBe("Acme Corp");
+  });
+
+  it("overwrites a previously set project", () => {
+    const session = createSession();
+    setProject(session, "proj_1", "Old Project");
+    setProject(session, "proj_2", "New Project");
+    expect(session.currentProjectId).toBe("proj_2");
+    expect(session.currentProjectName).toBe("New Project");
+  });
+});
+
+describe("getMessages", () => {
+  it("returns the messages array", () => {
+    const session = createSession();
+    addUserMessage(session, "Hello");
+    const msgs = getMessages(session);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content).toBe("Hello");
+  });
+
+  it("reflects subsequent mutations", () => {
+    const session = createSession();
+    const msgs = getMessages(session);
+    addUserMessage(session, "Added later");
+    expect(msgs).toHaveLength(1);
+  });
+});
+
+describe("getMessageCount", () => {
+  it("returns 0 for a new session", () => {
+    expect(getMessageCount(createSession())).toBe(0);
+  });
+
+  it("increments with each message added", () => {
+    const session = createSession();
+    addUserMessage(session, "one");
+    addUserMessage(session, "two");
+    expect(getMessageCount(session)).toBe(2);
+  });
+});
+
+describe("conversation turn ordering", () => {
+  it("builds alternating user/assistant/user structure", () => {
+    const session = createSession();
+    addUserMessage(session, "What's my traffic?");
+    addAssistantMessage(session, [{ type: "text", text: "Here is your traffic." }]);
+    addUserMessage(session, "What about rankings?");
+
+    const msgs = getMessages(session);
+    expect(msgs[0].role).toBe("user");
+    expect(msgs[1].role).toBe("assistant");
+    expect(msgs[2].role).toBe("user");
+  });
+
+  it("tool results are sent as user messages", () => {
+    const session = createSession();
+    addUserMessage(session, "Get status");
+    addAssistantMessage(session, [
+      { type: "tool_use", id: "t1", name: "get_status", input: {} },
+    ]);
+    addToolResults(session, [
+      { type: "tool_result", tool_use_id: "t1", content: "{}" },
+    ]);
+    const msgs = getMessages(session);
+    expect(msgs[2].role).toBe("user");
+  });
+});
+
+// ---- Prompt tests ----
+
+describe("buildSystemPrompt", () => {
+  it("includes the project name when provided", () => {
+    const prompt = buildSystemPrompt("Aqua Pro Vac");
+    expect(prompt).toContain("Aqua Pro Vac");
+  });
+
+  it("includes a message about no project when null", () => {
+    const prompt = buildSystemPrompt(null);
+    expect(prompt).toContain("list_projects");
+  });
+
+  it("mentions all available tools", () => {
+    const prompt = buildSystemPrompt("Test");
+    expect(prompt).toContain("list_projects");
+    expect(prompt).toContain("get_status");
+    expect(prompt).toContain("get_keywords");
+    expect(prompt).toContain("get_insights");
+    expect(prompt).toContain("get_geo");
+    expect(prompt).toContain("get_traffic");
+  });
+
+  it("returns a non-empty string", () => {
+    expect(buildSystemPrompt(null).length).toBeGreaterThan(100);
+  });
+
+  it("includes SEO domain guidance", () => {
+    const prompt = buildSystemPrompt("Site");
+    expect(prompt.toLowerCase()).toContain("ctr");
+    expect(prompt.toLowerCase()).toContain("ranking");
+  });
+});
+
+// ---- AGENT_TOOLS schema tests ----
+
+describe("AGENT_TOOLS definitions", () => {
+  const toolNames = AGENT_TOOLS.map((t) => t.name);
+
+  it("defines all 6 expected tools", () => {
+    expect(toolNames).toContain("list_projects");
+    expect(toolNames).toContain("get_status");
+    expect(toolNames).toContain("get_keywords");
+    expect(toolNames).toContain("get_insights");
+    expect(toolNames).toContain("get_geo");
+    expect(toolNames).toContain("get_traffic");
+    expect(AGENT_TOOLS).toHaveLength(6);
+  });
+
+  it("every tool has a name, description, and input_schema", () => {
+    for (const tool of AGENT_TOOLS) {
+      expect(typeof tool.name).toBe("string");
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(typeof tool.description).toBe("string");
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(tool.input_schema).toBeDefined();
+      expect(tool.input_schema.type).toBe("object");
+    }
+  });
+
+  it("tools that need a project_id mark it as required", () => {
+    const projectTools = AGENT_TOOLS.filter((t) => t.name !== "list_projects");
+    for (const tool of projectTools) {
+      expect(tool.input_schema.properties).toHaveProperty("project_id");
+      expect(tool.input_schema.required).toContain("project_id");
+    }
+  });
+
+  it("list_projects has no required parameters", () => {
+    const tool = AGENT_TOOLS.find((t) => t.name === "list_projects")!;
+    expect(tool.input_schema.required).toHaveLength(0);
+  });
+
+  it("get_keywords has an optional limit parameter", () => {
+    const tool = AGENT_TOOLS.find((t) => t.name === "get_keywords")!;
+    expect(tool.input_schema.properties).toHaveProperty("limit");
+    expect(tool.input_schema.required).not.toContain("limit");
+  });
+
+  it("get_insights has an optional limit parameter", () => {
+    const tool = AGENT_TOOLS.find((t) => t.name === "get_insights")!;
+    expect(tool.input_schema.properties).toHaveProperty("limit");
+    expect(tool.input_schema.required).not.toContain("limit");
+  });
+});
+
+// ---- executeTool tests ----
+
+describe("executeTool — list_projects", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns serialized project list", async () => {
+    vi.mocked(api.fetchProjects).mockResolvedValue([
+      {
+        id: "p1",
+        name: "Acme",
+        domain: "acme.com",
+        created_at: "2024-01-01",
+        search_console_connected: true,
+        google_analytics_connected: false,
+        shopify_connected: false,
+      },
+    ]);
+
+    const result = await executeTool("list_projects", {});
+    const parsed = JSON.parse(result);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].name).toBe("Acme");
+    expect(parsed[0].domain).toBe("acme.com");
+    expect(parsed[0].gsc_connected).toBe(true);
+    expect(parsed[0].ga4_connected).toBe(false);
+  });
+
+  it("returns 'No projects found.' when list is empty", async () => {
+    vi.mocked(api.fetchProjects).mockResolvedValue([]);
+    const result = await executeTool("list_projects", {});
+    expect(result).toBe("No projects found.");
+  });
+
+  it("returns error string when fetchProjects throws", async () => {
+    vi.mocked(api.fetchProjects).mockRejectedValue(new Error("Network error"));
+    const result = await executeTool("list_projects", {});
+    expect(result).toContain("Error");
+    expect(result).toContain("list_projects");
+  });
+});
+
+describe("executeTool — get_keywords", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches keywords for the given project_id", async () => {
+    vi.mocked(api.fetchTopKeywords).mockResolvedValue([
+      { keyword: "seo tools", position: 5, change: -2, impressions: 1000, clicks: 50 },
+    ]);
+
+    const result = await executeTool("get_keywords", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].keyword).toBe("seo tools");
+    expect(api.fetchTopKeywords).toHaveBeenCalledWith("p1", 20);
+  });
+
+  it("respects a custom limit (capped at 50)", async () => {
+    vi.mocked(api.fetchTopKeywords).mockResolvedValue([]);
+    await executeTool("get_keywords", { project_id: "p1", limit: 100 });
+    expect(api.fetchTopKeywords).toHaveBeenCalledWith("p1", 50);
+  });
+
+  it("uses default limit of 20 when none provided", async () => {
+    vi.mocked(api.fetchTopKeywords).mockResolvedValue([]);
+    await executeTool("get_keywords", { project_id: "p1" });
+    expect(api.fetchTopKeywords).toHaveBeenCalledWith("p1", 20);
+  });
+});
+
+describe("executeTool — get_insights", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches insights for the given project_id", async () => {
+    vi.mocked(api.fetchInsights).mockResolvedValue([
+      { id: "i1", severity: "warning", title: "CTR drop", summary: "CTR dropped 20%", estimated_impact_usd: 0 },
+    ]);
+
+    const result = await executeTool("get_insights", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(parsed[0].title).toBe("CTR drop");
+    expect(api.fetchInsights).toHaveBeenCalledWith("p1", 10);
+  });
+
+  it("uses default limit of 10", async () => {
+    vi.mocked(api.fetchInsights).mockResolvedValue([]);
+    await executeTool("get_insights", { project_id: "p1" });
+    expect(api.fetchInsights).toHaveBeenCalledWith("p1", 10);
+  });
+
+  it("respects a custom limit", async () => {
+    vi.mocked(api.fetchInsights).mockResolvedValue([]);
+    await executeTool("get_insights", { project_id: "p1", limit: 5 });
+    expect(api.fetchInsights).toHaveBeenCalledWith("p1", 5);
+  });
+});
+
+describe("executeTool — get_geo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches GEO metrics for the given project_id", async () => {
+    const mockGeo = {
+      totalCitations: 42,
+      citationRate: 35.5,
+      platforms: { ChatGPT: 20, Perplexity: 15, Gemini: 7 },
+      hasData: true,
+    };
+    vi.mocked(api.fetchGEOMetrics).mockResolvedValue(mockGeo);
+
+    const result = await executeTool("get_geo", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(parsed.totalCitations).toBe(42);
+    expect(parsed.citationRate).toBe(35.5);
+    expect(api.fetchGEOMetrics).toHaveBeenCalledWith("p1");
+  });
+});
+
+describe("executeTool — get_traffic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches both GSC and GA4 metrics", async () => {
+    vi.mocked(api.fetchGSCMetrics).mockResolvedValue({
+      clicks: 1000,
+      impressions: 50000,
+      ctr: 0.02,
+      position: 12.5,
+      hasData: true,
+    });
+    vi.mocked(api.fetchGA4Metrics).mockResolvedValue({
+      sessions: 800,
+      pageviews: 2400,
+      bounceRate: 45,
+      avgDuration: 180,
+      pagesPerSession: 3,
+      hasData: true,
+    });
+
+    const result = await executeTool("get_traffic", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(parsed.gsc.clicks).toBe(1000);
+    expect(parsed.ga4.sessions).toBe(800);
+  });
+
+  it("includes null for ga4 when it fails", async () => {
+    vi.mocked(api.fetchGSCMetrics).mockResolvedValue({
+      clicks: 500,
+      impressions: 10000,
+      ctr: 0.05,
+      position: 8,
+      hasData: true,
+    });
+    vi.mocked(api.fetchGA4Metrics).mockRejectedValue(new Error("Not connected"));
+
+    const result = await executeTool("get_traffic", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(parsed.gsc).toBeDefined();
+    expect(parsed.ga4).toBeNull();
+  });
+});
+
+describe("executeTool — get_status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns combined status data as JSON", async () => {
+    vi.mocked(api.fetchGSCMetricsWoW).mockResolvedValue({
+      current: { clicks: 500, impressions: 10000, ctr: 0.05, position: 8, hasData: true },
+      previous: { clicks: 400, impressions: 9000, ctr: 0.044, position: 9, hasData: true },
+      delta: {
+        clicks: { value: 100, pct: 25 },
+        impressions: { value: 1000, pct: 11.1 },
+        ctr: { value: 0.006, pct: 13.6 },
+        position: { value: -1, pct: -11.1 },
+      },
+    });
+    vi.mocked(api.fetchGA4MetricsWoW).mockRejectedValue(new Error("no data"));
+    vi.mocked(api.fetchGEOMetrics).mockRejectedValue(new Error("no data"));
+    vi.mocked(api.fetchRankingsSummary).mockResolvedValue({ top3: 5, top10: 20, top20: 40, total: 60 });
+    vi.mocked(api.fetchInsights).mockResolvedValue([]);
+    vi.mocked(api.fetchTopKeywords).mockResolvedValue([]);
+
+    const result = await executeTool("get_status", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(parsed).toHaveProperty("gscWoW");
+    expect(parsed).toHaveProperty("rankings");
+    expect(parsed.rankings.top3).toBe(5);
+    expect(parsed.ga4WoW).toBeNull();
+    expect(parsed.geo).toBeNull();
+  });
+});
+
+describe("executeTool — unknown tool", () => {
+  it("returns an unknown tool message", async () => {
+    const result = await executeTool("nonexistent_tool", {});
+    expect(result).toContain("Unknown tool");
+    expect(result).toContain("nonexistent_tool");
+  });
+});
+
+// ---- Tool chaining simulation ----
+
+describe("multi-tool session simulation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("session accumulates messages across multiple tool calls", async () => {
+    const session = createSession();
+    setProject(session, "p1", "Test Project");
+
+    // Simulate: user asks → assistant uses tool → tool result → assistant responds
+    addUserMessage(session, "How are my rankings?");
+
+    addAssistantMessage(session, [
+      { type: "tool_use", id: "t1", name: "get_keywords", input: { project_id: "p1" } },
+    ]);
+
+    addToolResults(session, [
+      { type: "tool_result", tool_use_id: "t1", content: '[{"keyword":"seo","position":3,"change":-1}]' },
+    ]);
+
+    addAssistantMessage(session, [
+      { type: "text", text: "Your top keyword 'seo' is at position 3, up 1 from last week." },
+    ]);
+
+    const msgs = getMessages(session);
+    expect(msgs).toHaveLength(4);
+    expect(msgs[0].role).toBe("user");
+    expect(msgs[1].role).toBe("assistant");
+    expect(msgs[2].role).toBe("user"); // tool results come back as user
+    expect(msgs[3].role).toBe("assistant");
+  });
+
+  it("session preserves project context across turns", () => {
+    const session = createSession();
+    setProject(session, "p1", "Aqua Pro Vac");
+
+    addUserMessage(session, "What are my top keywords?");
+    addUserMessage(session, "And my traffic?");
+
+    expect(session.currentProjectId).toBe("p1");
+    expect(session.currentProjectName).toBe("Aqua Pro Vac");
+  });
+});


### PR DESCRIPTION
## What
- Agent mode with Claude Opus tool chaining
- 6 tools: list_projects, get_status, get_keywords, get_insights, get_geo, get_traffic
- Session context management
- SEO/GEO domain knowledge system prompt
- 44 new tests

## Next
- Add missing agent tools (CRO, content, declining pages)
- npm publish prep (Phase 4)