### PR TITLE
feat: add missing agent tools + npm publish prep

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.0",
   "description": "Ezeo AI CLI — Talk to your SEO data",
   "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
   "bin": {
     "ezeo": "./dist/index.js"
   },

--- a/src/lib/agent/prompts.ts
+++ b/src/lib/agent/prompts.ts
@@ -17,6 +17,10 @@ You help users understand their SEO performance, identify opportunities, and mak
 - **get_insights**: Alerts and automated insights (ranking drops, traffic changes, opportunities)
 - **get_geo**: AI/GEO visibility — citation rate across ChatGPT, Perplexity, Gemini, and other AI platforms
 - **get_traffic**: Detailed traffic metrics from Search Console and Google Analytics
+- **get_cro**: CRO audit scores and findings plus pending CRO deliverables
+- **get_content_opportunities**: Content gap opportunities — keywords not ranking well but with high search volume
+- **get_declining_pages**: Pages with declining rankings over the past 30 days
+- **get_keyword_brief**: Generate a content brief for a keyword — current position, search volume, related keywords, and competitor URLs
 
 ## Tool Chaining
 Chain multiple tool calls when needed to give a complete answer:
@@ -24,6 +28,8 @@ Chain multiple tool calls when needed to give a complete answer:
 - For GEO recommendations: get_geo then get_insights together
 - For traffic diagnosis: get_traffic then get_keywords to correlate drops with ranking changes
 - To compare or switch projects: list_projects then get_status for the relevant project
+- For content strategy: get_content_opportunities then get_keyword_brief for the top opportunities
+- For site health: get_declining_pages and get_cro together to diagnose conversion and ranking issues
 
 ## Response Style
 - Be concise and data-driven — lead with the most important findings

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -9,6 +9,11 @@ import {
   fetchTopKeywords,
   fetchGSCMetrics,
   fetchGA4Metrics,
+  fetchCROAudits,
+  fetchCRODeliverables,
+  fetchContentOpportunities,
+  fetchDecliningPages,
+  fetchKeywordBriefData,
 } from "../api.js";
 
 export const AGENT_TOOLS: Anthropic.Tool[] = [
@@ -104,6 +109,78 @@ export const AGENT_TOOLS: Anthropic.Tool[] = [
       required: ["project_id"],
     },
   },
+  {
+    name: "get_cro",
+    description:
+      "Get CRO (Conversion Rate Optimization) audit scores and findings plus pending CRO deliverables for a project.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The project ID to get CRO data for",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
+    name: "get_content_opportunities",
+    description:
+      "Get content gap opportunities: keywords the site ranks for but not in the top 10, sorted by search volume. These are high-priority pages to refresh or improve.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The project ID to get content opportunities for",
+        },
+        limit: {
+          type: "number",
+          description: "Number of opportunities to fetch (default: 20)",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
+    name: "get_declining_pages",
+    description:
+      "Get pages with declining rankings over the past 30 days. Returns keywords where current position is worse than the position 30 days ago by at least the minimum drop threshold.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The project ID to get declining pages for",
+        },
+        min_drop: {
+          type: "number",
+          description: "Minimum position drop to include (default: 3). A drop of 3 means the keyword fell at least 3 positions.",
+        },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
+    name: "get_keyword_brief",
+    description:
+      "Generate a content brief for a specific keyword: current ranking position, search volume, related keywords, and competitor URLs. Use this before writing or refreshing content.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The project ID",
+        },
+        keyword: {
+          type: "string",
+          description: "The keyword to generate a brief for",
+        },
+      },
+      required: ["project_id", "keyword"],
+    },
+  },
 ];
 
 export async function executeTool(
@@ -168,6 +245,37 @@ export async function executeTool(
           fetchGA4Metrics(projectId).catch(() => null),
         ]);
         return JSON.stringify({ gsc, ga4 });
+      }
+
+      case "get_cro": {
+        const projectId = input.project_id as string;
+        const [audits, deliverables] = await Promise.all([
+          fetchCROAudits(projectId).catch(() => []),
+          fetchCRODeliverables(projectId).catch(() => []),
+        ]);
+        return JSON.stringify({ audits, deliverables });
+      }
+
+      case "get_content_opportunities": {
+        const projectId = input.project_id as string;
+        const limit = (input.limit as number | undefined) ?? 20;
+        const opportunities = await fetchContentOpportunities(projectId, limit);
+        return JSON.stringify(opportunities);
+      }
+
+      case "get_declining_pages": {
+        const projectId = input.project_id as string;
+        const minDrop = (input.min_drop as number | undefined) ?? 3;
+        const pages = await fetchDecliningPages(projectId, minDrop);
+        return JSON.stringify(pages);
+      }
+
+      case "get_keyword_brief": {
+        const projectId = input.project_id as string;
+        const keyword = input.keyword as string;
+        const brief = await fetchKeywordBriefData(projectId, keyword);
+        if (!brief) return `No data found for keyword: ${keyword}`;
+        return JSON.stringify(brief);
       }
 
       default:

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -22,6 +22,11 @@ vi.mock("../src/lib/api.js", () => ({
   fetchRankingsSummary: vi.fn(),
   fetchInsights: vi.fn(),
   fetchTopKeywords: vi.fn(),
+  fetchCROAudits: vi.fn(),
+  fetchCRODeliverables: vi.fn(),
+  fetchContentOpportunities: vi.fn(),
+  fetchDecliningPages: vi.fn(),
+  fetchKeywordBriefData: vi.fn(),
 }));
 
 import * as api from "../src/lib/api.js";
@@ -218,6 +223,10 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("get_insights");
     expect(prompt).toContain("get_geo");
     expect(prompt).toContain("get_traffic");
+    expect(prompt).toContain("get_cro");
+    expect(prompt).toContain("get_content_opportunities");
+    expect(prompt).toContain("get_declining_pages");
+    expect(prompt).toContain("get_keyword_brief");
   });
 
   it("returns a non-empty string", () => {
@@ -236,14 +245,18 @@ describe("buildSystemPrompt", () => {
 describe("AGENT_TOOLS definitions", () => {
   const toolNames = AGENT_TOOLS.map((t) => t.name);
 
-  it("defines all 6 expected tools", () => {
+  it("defines all 10 expected tools", () => {
     expect(toolNames).toContain("list_projects");
     expect(toolNames).toContain("get_status");
     expect(toolNames).toContain("get_keywords");
     expect(toolNames).toContain("get_insights");
     expect(toolNames).toContain("get_geo");
     expect(toolNames).toContain("get_traffic");
-    expect(AGENT_TOOLS).toHaveLength(6);
+    expect(toolNames).toContain("get_cro");
+    expect(toolNames).toContain("get_content_opportunities");
+    expect(toolNames).toContain("get_declining_pages");
+    expect(toolNames).toContain("get_keyword_brief");
+    expect(AGENT_TOOLS).toHaveLength(10);
   });
 
   it("every tool has a name, description, and input_schema", () => {
@@ -481,6 +494,173 @@ describe("executeTool — get_status", () => {
     expect(parsed.rankings.top3).toBe(5);
     expect(parsed.ga4WoW).toBeNull();
     expect(parsed.geo).toBeNull();
+  });
+});
+
+describe("executeTool — get_cro", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns combined audits and deliverables", async () => {
+    vi.mocked(api.fetchCROAudits).mockResolvedValue([
+      {
+        id: "a1",
+        project_id: "p1",
+        status: "completed",
+        created_at: "2024-01-01",
+        findings: [],
+        quick_wins: [],
+        overall_score: 72,
+        ux_score: 80,
+        performance_score: 65,
+        conversion_score: 70,
+        mobile_score: 75,
+        title: "Homepage Audit",
+        target_url: "https://acme.com",
+      },
+    ]);
+    vi.mocked(api.fetchCRODeliverables).mockResolvedValue([
+      {
+        id: "d1",
+        project_id: "p1",
+        title: "CTA button redesign",
+        status: "pending",
+        type: "design",
+        priority: "high",
+        created_at: "2024-01-02",
+      },
+    ]);
+
+    const result = await executeTool("get_cro", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(parsed).toHaveProperty("audits");
+    expect(parsed).toHaveProperty("deliverables");
+    expect(parsed.audits[0].overall_score).toBe(72);
+    expect(parsed.deliverables[0].title).toBe("CTA button redesign");
+    expect(api.fetchCROAudits).toHaveBeenCalledWith("p1");
+    expect(api.fetchCRODeliverables).toHaveBeenCalledWith("p1");
+  });
+
+  it("returns empty arrays when both calls fail", async () => {
+    vi.mocked(api.fetchCROAudits).mockRejectedValue(new Error("no data"));
+    vi.mocked(api.fetchCRODeliverables).mockRejectedValue(new Error("no data"));
+
+    const result = await executeTool("get_cro", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(parsed.audits).toEqual([]);
+    expect(parsed.deliverables).toEqual([]);
+  });
+});
+
+describe("executeTool — get_content_opportunities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns content opportunities for the project", async () => {
+    vi.mocked(api.fetchContentOpportunities).mockResolvedValue([
+      { keywordId: "k1", keyword: "seo software", searchVolume: 5000, currentPosition: 15 },
+      { keywordId: "k2", keyword: "rank tracker", searchVolume: 3000, currentPosition: 22 },
+    ]);
+
+    const result = await executeTool("get_content_opportunities", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].keyword).toBe("seo software");
+    expect(parsed[0].searchVolume).toBe(5000);
+    expect(api.fetchContentOpportunities).toHaveBeenCalledWith("p1", 20);
+  });
+
+  it("respects a custom limit", async () => {
+    vi.mocked(api.fetchContentOpportunities).mockResolvedValue([]);
+    await executeTool("get_content_opportunities", { project_id: "p1", limit: 5 });
+    expect(api.fetchContentOpportunities).toHaveBeenCalledWith("p1", 5);
+  });
+
+  it("uses default limit of 20 when none provided", async () => {
+    vi.mocked(api.fetchContentOpportunities).mockResolvedValue([]);
+    await executeTool("get_content_opportunities", { project_id: "p1" });
+    expect(api.fetchContentOpportunities).toHaveBeenCalledWith("p1", 20);
+  });
+});
+
+describe("executeTool — get_declining_pages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns declining pages for the project", async () => {
+    vi.mocked(api.fetchDecliningPages).mockResolvedValue([
+      {
+        keywordId: "k1",
+        keyword: "best seo tools",
+        url: "https://acme.com/seo-tools",
+        currentPosition: 18,
+        previousPosition: 8,
+        positionChange: 10,
+        latestCheckDate: "2024-01-15",
+      },
+    ]);
+
+    const result = await executeTool("get_declining_pages", { project_id: "p1" });
+    const parsed = JSON.parse(result);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].keyword).toBe("best seo tools");
+    expect(parsed[0].positionChange).toBe(10);
+    expect(api.fetchDecliningPages).toHaveBeenCalledWith("p1", 3);
+  });
+
+  it("respects a custom min_drop", async () => {
+    vi.mocked(api.fetchDecliningPages).mockResolvedValue([]);
+    await executeTool("get_declining_pages", { project_id: "p1", min_drop: 5 });
+    expect(api.fetchDecliningPages).toHaveBeenCalledWith("p1", 5);
+  });
+
+  it("uses default min_drop of 3 when none provided", async () => {
+    vi.mocked(api.fetchDecliningPages).mockResolvedValue([]);
+    await executeTool("get_declining_pages", { project_id: "p1" });
+    expect(api.fetchDecliningPages).toHaveBeenCalledWith("p1", 3);
+  });
+});
+
+describe("executeTool — get_keyword_brief", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a keyword brief when found", async () => {
+    vi.mocked(api.fetchKeywordBriefData).mockResolvedValue({
+      targetKeyword: "seo tools",
+      keywordId: "k1",
+      currentPosition: 7,
+      searchVolume: 8100,
+      relatedKeywords: [
+        { keyword: "best seo software", searchVolume: 4400, currentPosition: 12 },
+      ],
+      competitorUrls: ["https://competitor.com/seo-tools"],
+    });
+
+    const result = await executeTool("get_keyword_brief", { project_id: "p1", keyword: "seo tools" });
+    const parsed = JSON.parse(result);
+    expect(parsed.targetKeyword).toBe("seo tools");
+    expect(parsed.currentPosition).toBe(7);
+    expect(parsed.searchVolume).toBe(8100);
+    expect(api.fetchKeywordBriefData).toHaveBeenCalledWith("p1", "seo tools");
+  });
+
+  it("returns a not-found message when keyword does not exist", async () => {
+    vi.mocked(api.fetchKeywordBriefData).mockResolvedValue(null);
+    const result = await executeTool("get_keyword_brief", { project_id: "p1", keyword: "unknown kw" });
+    expect(result).toContain("No data found for keyword");
+    expect(result).toContain("unknown kw");
+  });
+
+  it("returns error string when API throws", async () => {
+    vi.mocked(api.fetchKeywordBriefData).mockRejectedValue(new Error("DB error"));
+    const result = await executeTool("get_keyword_brief", { project_id: "p1", keyword: "seo tools" });
+    expect(result).toContain("Error");
+    expect(result).toContain("get_keyword_brief");
   });
 });
 


### PR DESCRIPTION
## What
- **4 new agent tools:** get_cro, get_content_opportunities, get_declining_pages, get_keyword_brief
- **npm publish prep:** added main + exports fields to package.json
- **11 new tests** (342 → 353 all passing)

## Agent tools now: 10 total
| Tool | Description |
|------|-------------|
| list_projects | List all projects |
| get_status | Full dashboard |
| get_keywords | Top keywords + position changes |
| get_insights | Alerts and opportunities |
| get_geo | AI visibility / citations |
| get_traffic | GSC + GA4 metrics |
| **get_cro** | CRO audits + deliverables |
| **get_content_opportunities** | Content gaps by search volume |
| **get_declining_pages** | Pages losing rankings |
| **get_keyword_brief** | Content brief for a keyword |

## npm publish
- Added `main` and `exports` fields
- `publishConfig`, `prepublishOnly`, `files` already existed from Phase 4